### PR TITLE
refactor: rename session to cookie

### DIFF
--- a/app/Support/CurrentPlayer/Adapters/CookiePlayer.php
+++ b/app/Support/CurrentPlayer/Adapters/CookiePlayer.php
@@ -7,7 +7,7 @@ use App\Support\CurrentPlayer\Contracts\PlayerAdapter;
 use Cookie;
 use Illuminate\Http\Request;
 
-class SessionPlayer implements PlayerAdapter {
+class CookiePlayer implements PlayerAdapter {
     private string $cookieName;
     private Request $request;
 

--- a/app/Support/CurrentPlayer/Providers/CurrentPlayerProvider.php
+++ b/app/Support/CurrentPlayer/Providers/CurrentPlayerProvider.php
@@ -3,7 +3,7 @@
 namespace App\Support\CurrentPlayer\Providers;
 
 use App\Events\PlayerJoinedGame;
-use App\Support\CurrentPlayer\Adapters\SessionPlayer;
+use App\Support\CurrentPlayer\Adapters\CookiePlayer;
 use App\Support\CurrentPlayer\Contracts\PlayerAdapter;
 use App\Support\CurrentPlayer\CurrentPlayer;
 use App\Support\CurrentPlayer\Listeners\SetCurrentPlayer as SetCurrentPlayerListener;
@@ -19,7 +19,7 @@ class CurrentPlayerProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(PlayerAdapter::class, fn () => app(match (config('game.current_player.driver')) {
-            'session' => SessionPlayer::class
+            'cookie' => CookiePlayer::class
         }));
 
         $this->app->singleton(CurrentPlayer::class);

--- a/config/game.php
+++ b/config/game.php
@@ -2,7 +2,7 @@
 
 return [
     'current_player' => [
-        'driver' => 'session',
+        'driver' => 'cookie',
         'cookie_name' => 'player_id'
     ]
 ];

--- a/tests/Unit/Support/CurrentPlayer/Adapters/CookiePlayerTest.php
+++ b/tests/Unit/Support/CurrentPlayer/Adapters/CookiePlayerTest.php
@@ -2,13 +2,13 @@
 
 namespace Unit\Support\CurrentPlayer\Adapters;
 
-use App\Support\CurrentPlayer\Adapters\SessionPlayer;
+use App\Support\CurrentPlayer\Adapters\CookiePlayer;
 use Config;
 use Database\Factories\PlayerFactory;
 use Illuminate\Http\Request;
 use Tests\TestCase;
 
-class SessionPlayerTest extends TestCase {
+class CookiePlayerTest extends TestCase {
     function test_it_retrieves_player_from_cookie() {
         $cookieName = 'cookieName';
 
@@ -16,9 +16,9 @@ class SessionPlayerTest extends TestCase {
         $expectedPlayer = PlayerFactory::new()->create();
         $this->spy(Request::class)->shouldReceive('cookie')->with($cookieName)->andReturn($expectedPlayer->id);
 
-        $sessionPlayer = $this->app->make(SessionPlayer::class);
+        $cookiePlayer = $this->app->make(CookiePlayer::class);
 
-        $actualPlayer = $sessionPlayer->retrieve();
+        $actualPlayer = $cookiePlayer->retrieve();
         $this->assertEquals($expectedPlayer->id, $actualPlayer->id);
     }
 
@@ -27,8 +27,8 @@ class SessionPlayerTest extends TestCase {
 
         Config::set('game.current_player.cookie_name', $cookieName);
         $player = PlayerFactory::new()->create();
-        $sessionPlayer = $this->app->make(SessionPlayer::class);
-        $sessionPlayer->set($player);
+        $cookiePlayer = $this->app->make(CookiePlayer::class);
+        $cookiePlayer->set($player);
 
         $this->get('/')->assertCookie($cookieName, $player->id);
     }

--- a/tests/Unit/Support/CurrentPlayer/Providers/CurrentPlayerProviderTest.php
+++ b/tests/Unit/Support/CurrentPlayer/Providers/CurrentPlayerProviderTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit\Support\CurrentPlayer\Providers;
 
-use App\Support\CurrentPlayer\Adapters\SessionPlayer;
+use App\Support\CurrentPlayer\Adapters\CookiePlayer;
 use App\Support\CurrentPlayer\Contracts\PlayerAdapter;
 use App\Support\CurrentPlayer\CurrentPlayer;
 use App\Support\CurrentPlayer\Providers\CurrentPlayerProvider;
@@ -20,13 +20,13 @@ class CurrentPlayerProviderTest extends TestCase
         $this->assertSame($intance1, $intance2);
     }
 
-    function test_it_binds_session_player_to_http_player() {
+    function test_it_binds_cookie_player_to_http_player() {
         $provider = new CurrentPlayerProvider($this->app);
 
-        \Config::set('game.current_player.driver', 'session');
+        \Config::set('game.current_player.driver', 'cookie');
 
         $provider->register();
 
-        $this->assertInstanceOf(SessionPlayer::class, $this->app->make(PlayerAdapter::class));
+        $this->assertInstanceOf(CookiePlayer::class, $this->app->make(PlayerAdapter::class));
     }
 }


### PR DESCRIPTION
I renamed all references to 'session' as 'cookie.' Please review and check for any issues.